### PR TITLE
Relax performance requirements for template tests

### DIFF
--- a/cms-templates/src/test/java/com/condation/cms/templates/perf/TemplatePerformanceTest.java
+++ b/cms-templates/src/test/java/com/condation/cms/templates/perf/TemplatePerformanceTest.java
@@ -94,14 +94,14 @@ public class TemplatePerformanceTest {
 
     @Test
     @JUnitPerfTest(threads = 10, durationMs = 10_000, warmUpMs = 2_000)
-    @JUnitPerfTestRequirement(maxLatency = 100, meanLatency = 50)
+    @JUnitPerfTestRequirement(percentiles = "90:100", meanLatency = 50)
     public void testSimpleTemplatePerformance() throws java.io.IOException {
         SIMPLE_TEMPLATE.evaluate(Map.of("name", "CondationCMS"));
     }
 
     @Test
     @JUnitPerfTest(threads = 10, durationMs = 10_000, warmUpMs = 2_000)
-    @JUnitPerfTestRequirement(maxLatency = 200, meanLatency = 100)
+    @JUnitPerfTestRequirement(percentiles = "90:200", meanLatency = 100)
     public void testComplexTemplatePerformance() throws java.io.IOException {
         COMPLEX_TEMPLATE.evaluate(CONTEXT);
     }


### PR DESCRIPTION
Adjusted the performance tests in the `cms-templates` module to use percentiles instead of a strict maximum latency. This makes the tests more resilient to fluctuations in CI environments like GitHub Actions, where occasional jitter can cause tests to fail even if the overall performance is acceptable.

---
*PR created automatically by Jules for task [1269847510372744622](https://jules.google.com/task/1269847510372744622) started by @thmarx*